### PR TITLE
Add drag and drop reordering for job cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@fortawesome/fontawesome-svg-core": "^7.0.1",
         "@fortawesome/free-solid-svg-icons": "^7.0.1",
         "@fortawesome/react-fontawesome": "^3.0.2",
+        "@hello-pangea/dnd": "^18.0.1",
         "classnames": "^2.3.2",
         "customize-cra": "^1.0.0",
         "dexie": "^3.2.2",
@@ -2492,6 +2493,52 @@
         "react": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@hello-pangea/dnd": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-18.0.1.tgz",
+      "integrity": "sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "css-box-model": "^1.2.1",
+        "raf-schd": "^4.0.3",
+        "react-redux": "^9.2.0",
+        "redux": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@hello-pangea/dnd/node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@hello-pangea/dnd/node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -3970,6 +4017,12 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -17435,6 +17488,15 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@fortawesome/fontawesome-svg-core": "^7.0.1",
     "@fortawesome/free-solid-svg-icons": "^7.0.1",
     "@fortawesome/react-fontawesome": "^3.0.2",
+    "@hello-pangea/dnd": "^18.0.1",
     "classnames": "^2.3.2",
     "customize-cra": "^1.0.0",
     "dexie": "^3.2.2",

--- a/src/components/jobs/JobsBoard.jsx
+++ b/src/components/jobs/JobsBoard.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd'
+import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd'
 import CreateEditJobModal from './CreateEditJobModal'
 import LiveTimer from './LiveTimer'
 import Notification from '../common/Notification'

--- a/src/components/jobs/JobsBoard.jsx
+++ b/src/components/jobs/JobsBoard.jsx
@@ -31,13 +31,16 @@ export default function JobsBoard() {
       const pageSize = viewMode === 'kanban' ? 1000 : itemsPerPage
       const currentPage = viewMode === 'kanban' ? 1 : page
       
+      const effectiveSortBy = viewMode === 'kanban' ? 'order' : sortBy
+      const effectiveSortOrder = viewMode === 'kanban' ? 'asc' : sortOrder
+
       const params = new URLSearchParams({
         page: currentPage.toString(),
         pageSize: pageSize.toString(),
         ...(search && { search }),
         ...(statusFilter && { status: statusFilter }),
-        ...(sortBy && { sortBy }),
-        ...(sortOrder && { sortOrder })
+        ...(effectiveSortBy && { sortBy: effectiveSortBy }),
+        ...(effectiveSortOrder && { sortOrder: effectiveSortOrder })
       })
       
       const response = await fetch(`/api/jobs?${params}`)
@@ -217,12 +220,51 @@ export default function JobsBoard() {
         })
       }
     } else {
-      // Handle reordering within the same column
-      console.log('🔄 Reordering within same column')
-      setNotification({
-        message: `Reordering within columns coming soon!`,
-        type: 'info'
-      })
+      // Handle reordering within the same column (by order index)
+      try {
+        const allSorted = jobs.slice().sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+        const sourceItemIndex = allSorted.findIndex((it) => it.id === job.id)
+        const fromOrder = sourceItemIndex === -1 ? (job.order ?? 0) : sourceItemIndex
+
+        // Remove the dragged item to compute destination index correctly
+        const withoutSource = allSorted.filter((it) => it.id !== job.id)
+        const columnStatus = source.droppableId
+        const columnIndices = withoutSource
+          .map((it, idx) => ({ it, idx }))
+          .filter(({ it }) => it.status === columnStatus)
+          .map(({ idx }) => idx)
+
+        // Map destination (column-based) index to global order index
+        let toOrder
+        if (destination.index >= columnIndices.length) {
+          // Insert after the last item of the column (at the end)
+          toOrder = columnIndices.length > 0 ? columnIndices[columnIndices.length - 1] + 1 : withoutSource.length
+        } else {
+          toOrder = columnIndices[destination.index]
+        }
+
+        const res = await fetch(`/api/jobs/${jobId}/reorder`, {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ fromOrder, toOrder })
+        })
+        if (!res.ok) {
+          const errData = await res.json().catch(() => ({}))
+          throw new Error(errData.error || 'Failed to reorder')
+        }
+
+        setNotification({
+          message: `Reordered "${job.title}"`,
+          type: 'success'
+        })
+        loadJobs()
+      } catch (e) {
+        console.error('❌ Reorder failed:', e)
+        setNotification({
+          message: `Failed to reorder: ${e.message}`,
+          type: 'error'
+        })
+      }
     }
   }
 


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR implements drag and drop functionality for job cards to improve the user experience. The users specifically requested drag and drop effects for job cards, and there was also a runtime error that needed to be fixed.

## Code changes

- **Added @hello-pangea/dnd dependency**: Migrated from `react-beautiful-dnd` to `@hello-pangea/dnd` (v18.0.1) to resolve runtime issues and provide better React 18+ support
- **Implemented job reordering logic**: Added complete drag and drop reordering functionality within the same column using order indices
- **Enhanced API integration**: Added `/api/jobs/{id}/reorder` endpoint calls with proper error handling
- **Improved sorting logic**: Updated job loading to use 'order' field for kanban view sorting
- **Added user feedback**: Implemented success/error notifications for reorder operations

The implementation handles both cross-column status changes and within-column reordering, with proper order index calculations and API error handling.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/87b8c3d7529c4af8a3ea284e99dbfcfb/neon-home)

👀 [Preview Link](https://87b8c3d7529c4af8a3ea284e99dbfcfb-neon-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>87b8c3d7529c4af8a3ea284e99dbfcfb</projectId>-->
<!--<branchName>neon-home</branchName>-->